### PR TITLE
Implement parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
+name = "fd-lock"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+
+[[package]]
+name = "log"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,6 +133,7 @@ version = "0.1.0"
 dependencies = [
  "nom",
  "nom-regex",
+ "rustyline",
 ]
 
 [[package]]
@@ -30,6 +141,27 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
 
 [[package]]
 name = "nom"
@@ -52,6 +184,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "regex"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,3 +209,169 @@ name = "regex-syntax"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+
+[[package]]
+name = "rustix"
+version = "0.38.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustyline"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994eca4bca05c87e86e15d90fc7a91d1be64b4482b38cb2d27474568fe7c9db9"
+dependencies = [
+ "bitflags 2.3.3",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "smallvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ version = "0.1.0"
 dependencies = [
  "nom",
  "nom-regex",
+ "once_cell",
  "rustyline",
 ]
 
@@ -182,6 +183,12 @@ dependencies = [
  "nom",
  "regex",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "radix_trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "emojis"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15f3d10f3c4086c618edd197ad5b9084eb35d640d68d6f5dd34d6f54b3150f5"
+dependencies = [
+ "phf",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,10 +140,12 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 name = "mfm"
 version = "0.1.0"
 dependencies = [
+ "emojis",
  "nom",
  "nom-regex",
  "once_cell",
  "rustyline",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -191,6 +202,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,9 +231,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -213,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
 name = "rustix"
@@ -258,6 +299,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+emojis = "0.6"
 nom = "7.1.3"
 nom-regex = "0.2.0"
 once_cell = "1.18"
+unicode-segmentation = "1.10"
 
 [dev-dependencies]
 rustyline = "12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 nom = "7.1.3"
 nom-regex = "0.2.0"
+once_cell = "1.18"
 
 [dev-dependencies]
 rustyline = "12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 [dependencies]
 nom = "7.1.3"
 nom-regex = "0.2.0"
+
+[dev-dependencies]
+rustyline = "12.0"

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -1,0 +1,44 @@
+use std::time::Instant;
+
+use rustyline::error::ReadlineError;
+use rustyline::{DefaultEditor, Result};
+
+fn main() -> Result<()> {
+    let mut rl = DefaultEditor::new()?;
+    println!("interactive parser");
+    println!("Ctrl+D to exit.");
+    loop {
+        let readline = rl.readline("> ");
+        match readline {
+            Ok(line) => {
+                rl.add_history_entry(&line)?;
+                let line = line
+                    .replace(r"\n", "\n")
+                    .replace(r"\r", "\r")
+                    .replace(r"\u00a0", "\u{00a0}");
+                let start = Instant::now();
+                let result = mfm::parse(&line);
+                let end = start.elapsed();
+                match result {
+                    Ok(nodes) => {
+                        println!("{nodes:?}");
+                        println!("parsing time: {:.3}ms", end.as_micros() as f64 / 1000.0)
+                    }
+                    Err(err) => eprintln!("Error: {err:?}"),
+                }
+            }
+            Err(ReadlineError::Interrupted) => {
+                println!("Interrupted.");
+            }
+            Err(ReadlineError::Eof) => {
+                println!("Bye.");
+                break;
+            }
+            Err(err) => {
+                eprintln!("Error: {err:?}");
+                break;
+            }
+        }
+    }
+    Ok(())
+}

--- a/examples/parse_simple.rs
+++ b/examples/parse_simple.rs
@@ -1,0 +1,44 @@
+use std::time::Instant;
+
+use rustyline::error::ReadlineError;
+use rustyline::{DefaultEditor, Result};
+
+fn main() -> Result<()> {
+    let mut rl = DefaultEditor::new()?;
+    println!("interactive simple parser");
+    println!("Ctrl+D to exit.");
+    loop {
+        let readline = rl.readline("> ");
+        match readline {
+            Ok(line) => {
+                rl.add_history_entry(&line)?;
+                let line = line
+                    .replace(r"\n", "\n")
+                    .replace(r"\r", "\r")
+                    .replace(r"\u00a0", "\u{00a0}");
+                let start = Instant::now();
+                let result = mfm::parse_simple(&line);
+                let end = start.elapsed();
+                match result {
+                    Ok(nodes) => {
+                        println!("{nodes:?}");
+                        println!("parsing time: {:.3}ms", end.as_micros() as f64 / 1000.0)
+                    }
+                    Err(err) => eprintln!("Error: {err:?}"),
+                }
+            }
+            Err(ReadlineError::Interrupted) => {
+                println!("Interrupted.");
+            }
+            Err(ReadlineError::Eof) => {
+                println!("Bye.");
+                break;
+            }
+            Err(err) => {
+                eprintln!("Error: {err:?}");
+                break;
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,7 @@
-use crate::{node::Node, parser::FullParser, util::merge_text};
+use crate::{
+    node::{Node, Simple},
+    parser::{FullParser, SimpleParser},
+};
 
 /// Generates a MFM Node tree from the MFM string.
 pub fn parse(input: &str) -> Result<Vec<Node>, nom::Err<nom::error::Error<&str>>> {
@@ -13,4 +16,9 @@ pub fn parse_with_nest_limit(
     FullParser::new(nest_limit)
         .parse(input)
         .map(|(_, nodes)| nodes)
+}
+
+/// Generates a MFM Simple Node tree from the MFM string.
+pub fn parse_simple(input: &str) -> Result<Vec<Simple>, nom::Err<nom::error::Error<&str>>> {
+    SimpleParser::parse(input).map(|(_, nodes)| nodes)
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,16 @@
+use crate::{node::Node, parser::FullParser, util::merge_text};
+
+/// Generates a MFM Node tree from the MFM string.
+pub fn parse(input: &str) -> Result<Vec<Node>, nom::Err<nom::error::Error<&str>>> {
+    FullParser::default().parse(input).map(|(_, nodes)| nodes)
+}
+
+/// Generates a MFM Node tree from the MFM string with a specific maximum nest depth.
+pub fn parse_with_nest_limit(
+    input: &str,
+    nest_limit: u32,
+) -> Result<Vec<Node>, nom::Err<nom::error::Error<&str>>> {
+    FullParser::new(nest_limit)
+        .parse(input)
+        .map(|(_, nodes)| nodes)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,4 @@ pub mod node;
 pub mod parser;
 mod util;
 
-pub use api::{parse, parse_with_nest_limit};
+pub use api::{parse, parse_simple, parse_with_nest_limit};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,6 @@
+mod api;
 pub mod node;
 pub mod parser;
+mod util;
+
+pub use api::{parse, parse_with_nest_limit};

--- a/src/node.rs
+++ b/src/node.rs
@@ -116,6 +116,7 @@ pub struct Url {
 pub struct Link {
     pub url: String,
     pub silent: bool,
+    pub children: Vec<Inline>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -122,6 +122,7 @@ pub struct Link {
 pub struct Fn {
     pub name: String,
     pub args: Vec<(String, Option<String>)>,
+    pub children: Vec<Inline>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -73,16 +73,16 @@ pub struct EmojiCode {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Bold(Vec<Inline>);
+pub struct Bold(pub Vec<Inline>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Small(Vec<Inline>);
+pub struct Small(pub Vec<Inline>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Italic(Vec<Inline>);
+pub struct Italic(pub Vec<Inline>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Strike(Vec<Inline>);
+pub struct Strike(pub Vec<Inline>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct InlineCode {

--- a/src/node.rs
+++ b/src/node.rs
@@ -131,3 +131,15 @@ pub struct Plain(pub Vec<Text>);
 pub struct Text {
     pub text: String,
 }
+
+impl From<Text> for Node {
+    fn from(text: Text) -> Self {
+        Node::Inline(Inline::Text(text))
+    }
+}
+
+impl From<Text> for Inline {
+    fn from(text: Text) -> Self {
+        Inline::Text(text)
+    }
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,129 +1,129 @@
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Node<'a> {
-    Block(Block<'a>),
-    Inline(Inline<'a>),
+pub enum Node {
+    Block(Block),
+    Inline(Inline),
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Block<'a> {
-    Quote(Quote<'a>),
-    Search(Search<'a>),
-    CodeBlock(CodeBlock<'a>),
-    MathBlock(MathBlock<'a>),
+pub enum Block {
+    Quote(Quote),
+    Search(Search),
+    CodeBlock(CodeBlock),
+    MathBlock(MathBlock),
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Quote<'a>(Vec<Node<'a>>);
+pub struct Quote(pub Vec<Node>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Search<'a> {
-    pub query: &'a str,
-    pub content: &'a str,
+pub struct Search {
+    pub query: String,
+    pub content: String,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct CodeBlock<'a> {
-    pub code: &'a str,
-    pub lang: Option<&'a str>,
+pub struct CodeBlock {
+    pub code: String,
+    pub lang: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct MathBlock<'a> {
-    pub formula: &'a str,
+pub struct MathBlock {
+    pub formula: String,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Inline<'a> {
-    UnicodeEmoji(UnicodeEmoji<'a>),
-    EmojiCode(EmojiCode<'a>),
-    Bold(Bold<'a>),
-    Small(Small<'a>),
-    Italic(Italic<'a>),
-    Strike(Strike<'a>),
-    InlineCode(InlineCode<'a>),
-    MathInline(MathInline<'a>),
-    Mention(Mention<'a>),
-    Hashtag(Hashtag<'a>),
-    Url(Url<'a>),
-    Link(Link<'a>),
-    Fn(Fn<'a>),
-    Plain(Plain<'a>),
-    Text(Text<'a>),
+pub enum Inline {
+    UnicodeEmoji(UnicodeEmoji),
+    EmojiCode(EmojiCode),
+    Bold(Bold),
+    Small(Small),
+    Italic(Italic),
+    Strike(Strike),
+    InlineCode(InlineCode),
+    MathInline(MathInline),
+    Mention(Mention),
+    Hashtag(Hashtag),
+    Url(Url),
+    Link(Link),
+    Fn(Fn),
+    Plain(Plain),
+    Text(Text),
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Simple<'a> {
-    UnicodeEmoji(UnicodeEmoji<'a>),
-    EmojiCode(EmojiCode<'a>),
-    Text(Text<'a>),
+pub enum Simple {
+    UnicodeEmoji(UnicodeEmoji),
+    EmojiCode(EmojiCode),
+    Text(Text),
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct UnicodeEmoji<'a> {
-    pub emoji: &'a str,
+pub struct UnicodeEmoji {
+    pub emoji: String,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct EmojiCode<'a> {
-    pub name: &'a str,
+pub struct EmojiCode {
+    pub name: String,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Bold<'a>(Vec<Inline<'a>>);
+pub struct Bold(Vec<Inline>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Small<'a>(Vec<Inline<'a>>);
+pub struct Small(Vec<Inline>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Italic<'a>(Vec<Inline<'a>>);
+pub struct Italic(Vec<Inline>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Strike<'a>(Vec<Inline<'a>>);
+pub struct Strike(Vec<Inline>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct InlineCode<'a> {
-    pub code: &'a str,
+pub struct InlineCode {
+    pub code: String,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct MathInline<'a> {
-    pub formula: &'a str,
+pub struct MathInline {
+    pub formula: String,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Mention<'a> {
-    pub username: &'a str,
-    pub host: Option<&'a str>,
-    pub acct: &'a str,
+pub struct Mention {
+    pub username: String,
+    pub host: Option<String>,
+    pub acct: String,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Hashtag<'a> {
-    pub hashtag: &'a str,
+pub struct Hashtag {
+    pub hashtag: String,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Url<'a> {
-    pub url: &'a str,
+pub struct Url {
+    pub url: String,
     pub brackets: bool,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Link<'a> {
-    pub url: &'a str,
+pub struct Link {
+    pub url: String,
     pub silent: bool,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Fn<'a> {
-    pub name: &'a str,
-    pub args: Vec<(&'a str, Option<&'a str>)>,
+pub struct Fn {
+    pub name: String,
+    pub args: Vec<(String, Option<String>)>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Plain<'a>(Vec<Text<'a>>);
+pub struct Plain(pub Vec<Text>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Text<'a> {
-    pub text: &'a str,
+pub struct Text {
+    pub text: String,
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -10,6 +10,7 @@ pub enum Block {
     Search(Search),
     CodeBlock(CodeBlock),
     MathBlock(MathBlock),
+    Center(Center),
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -31,6 +32,9 @@ pub struct CodeBlock {
 pub struct MathBlock {
     pub formula: String,
 }
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Center(pub Vec<Inline>);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Inline {

--- a/src/node.rs
+++ b/src/node.rs
@@ -150,3 +150,9 @@ impl From<Text> for Simple {
         Simple::Text(text)
     }
 }
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum ValueOrText<T> {
+    Value(T),
+    Text(Text),
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -143,3 +143,9 @@ impl From<Text> for Inline {
         Inline::Text(text)
     }
 }
+
+impl From<Text> for Simple {
+    fn from(text: Text) -> Self {
+        Simple::Text(text)
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -344,6 +344,7 @@ impl FullParser {
             map(|s| self.parse_small(s), Inline::Small),
             map(|s| self.parse_italic(s, last_char), Inline::Italic),
             map(|s| self.parse_strike(s), Inline::Strike),
+            map(Self::parse_inline_code, Inline::InlineCode),
             map(Self::parse_plain, Inline::Plain),
             map(Self::parse_text, Inline::Text),
         ))(input)
@@ -635,7 +636,23 @@ impl FullParser {
     }
 
     fn parse_inline_code<'a>(input: &'a str) -> IResult<&'a str, InlineCode> {
-        todo!()
+        delimited(
+            char('`'),
+            map(
+                recognize(many1(preceded(
+                    not(alt((
+                        value((), char('`')),
+                        value((), char('´')),
+                        value((), line_ending),
+                    ))),
+                    anychar,
+                ))),
+                |code: &str| InlineCode {
+                    code: code.to_string(),
+                },
+            ),
+            char('`'),
+        )(input)
     }
 
     fn parse_math_inline<'a>(input: &'a str) -> IResult<&'a str, MathInline> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,7 +11,7 @@ use nom::{
 
 use crate::{
     node::*,
-    util::{merge_text, merge_text_inline},
+    util::{merge_text, merge_text_inline, merge_text_simple},
 };
 
 fn failure<'a>(input: &'a str) -> nom::error::Error<&'a str> {
@@ -28,6 +28,23 @@ fn line_end<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, (), 
         value((), verify(rest, |s: &str| s.is_empty())),
         value((), peek(line_ending)),
     ))(input)
+}
+
+/// Parser for partial MFM syntax.
+#[derive(Clone, Debug)]
+pub struct SimpleParser {}
+
+impl SimpleParser {
+    /// Returns a simple MFM node tree.
+    pub fn parse<'a>(input: &'a str) -> IResult<&'a str, Vec<Simple>> {
+        map(
+            many0(alt((
+                map(|s| FullParser::parse_emoji_code(s), Simple::EmojiCode),
+                map(|s| FullParser::parse_text(s), Simple::Text),
+            ))),
+            merge_text_simple,
+        )(input)
+    }
 }
 
 /// Parser for full MFM syntax.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -345,6 +345,7 @@ impl FullParser {
             map(|s| self.parse_italic(s, last_char), Inline::Italic),
             map(|s| self.parse_strike(s), Inline::Strike),
             map(Self::parse_inline_code, Inline::InlineCode),
+            map(Self::parse_math_inline, Inline::MathInline),
             map(Self::parse_plain, Inline::Plain),
             map(Self::parse_text, Inline::Text),
         ))(input)
@@ -656,7 +657,21 @@ impl FullParser {
     }
 
     fn parse_math_inline<'a>(input: &'a str) -> IResult<&'a str, MathInline> {
-        todo!()
+        const OPEN: &str = r"\(";
+        const CLOSE: &str = r"\)";
+        delimited(
+            tag(OPEN),
+            map(
+                recognize(many1(preceded(
+                    not(alt((tag(CLOSE), line_ending))),
+                    anychar,
+                ))),
+                |formula: &str| MathInline {
+                    formula: formula.to_string(),
+                },
+            ),
+            tag(CLOSE),
+        )(input)
     }
 
     fn parse_mention<'a>(input: &'a str) -> IResult<&'a str, Mention> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -81,7 +81,7 @@ impl FullParser {
             map(|s| self.parse_quote(s), Block::Quote),
             map(Self::parse_search, Block::Search),
             map(Self::parse_code_block, Block::CodeBlock),
-            // map(Self::parse_math_block, Block::MathBlock),
+            map(Self::parse_math_block, Block::MathBlock),
         ))(input)
     }
 
@@ -179,7 +179,29 @@ impl FullParser {
     }
 
     fn parse_math_block<'a>(input: &'a str) -> IResult<&'a str, MathBlock> {
-        todo!()
+        const OPEN: &str = r"\[";
+        const CLOSE: &str = r"\]";
+        delimited(
+            opt(line_ending),
+            delimited(
+                tag(OPEN),
+                delimited(
+                    opt(line_ending),
+                    map(
+                        recognize(many1(preceded(
+                            not(pair(opt(line_ending), tag(CLOSE))),
+                            anychar,
+                        ))),
+                        |formula: &str| MathBlock {
+                            formula: formula.to_string(),
+                        },
+                    ),
+                    opt(line_ending),
+                ),
+                pair(tag(CLOSE), line_end),
+            ),
+            opt(line_ending),
+        )(input)
     }
 
     fn parse_inline<'a>(&self, input: &'a str) -> IResult<&'a str, Inline> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,14 +2,14 @@ use nom::{branch::alt, combinator::map, multi::many0, IResult};
 
 use crate::node::*;
 
-pub fn parse<'a>(input: &'a str) -> IResult<&'a str, Vec<Node<'a>>> {
+pub fn parse<'a>(input: &'a str) -> IResult<&'a str, Vec<Node>> {
     many0(alt((
         map(parse_block, Node::Block),
         map(parse_inline, Node::Inline),
     )))(input)
 }
 
-fn parse_block<'a>(input: &'a str) -> IResult<&'a str, Block<'a>> {
+fn parse_block<'a>(input: &'a str) -> IResult<&'a str, Block> {
     alt((
         map(parse_quote, Block::Quote),
         map(parse_search, Block::Search),
@@ -22,78 +22,78 @@ fn parse_quote<'a>(input: &'a str) -> IResult<&'a str, Quote> {
     todo!()
 }
 
-fn parse_search<'a>(input: &'a str) -> IResult<&'a str, Search<'a>> {
+fn parse_search<'a>(input: &'a str) -> IResult<&'a str, Search> {
     todo!()
 }
 
-fn parse_code_block<'a>(input: &'a str) -> IResult<&'a str, CodeBlock<'a>> {
+fn parse_code_block<'a>(input: &'a str) -> IResult<&'a str, CodeBlock> {
     todo!()
 }
 
-fn parse_math_block<'a>(input: &'a str) -> IResult<&'a str, MathBlock<'a>> {
+fn parse_math_block<'a>(input: &'a str) -> IResult<&'a str, MathBlock> {
     todo!()
 }
 
-fn parse_inline<'a>(input: &'a str) -> IResult<&'a str, Inline<'a>> {
+fn parse_inline<'a>(input: &'a str) -> IResult<&'a str, Inline> {
     todo!()
 }
 
-fn parse_unicode_emoji<'a>(input: &'a str) -> IResult<&'a str, UnicodeEmoji<'a>> {
+fn parse_unicode_emoji<'a>(input: &'a str) -> IResult<&'a str, UnicodeEmoji> {
     todo!()
 }
 
-fn parse_emoji_code<'a>(input: &'a str) -> IResult<&'a str, EmojiCode<'a>> {
+fn parse_emoji_code<'a>(input: &'a str) -> IResult<&'a str, EmojiCode> {
     todo!()
 }
 
-fn parse_bold<'a>(input: &'a str) -> IResult<&'a str, Bold<'a>> {
+fn parse_bold<'a>(input: &'a str) -> IResult<&'a str, Bold> {
     todo!()
 }
 
-fn parse_small<'a>(input: &'a str) -> IResult<&'a str, Small<'a>> {
+fn parse_small<'a>(input: &'a str) -> IResult<&'a str, Small> {
     todo!()
 }
 
-fn parse_italic<'a>(input: &'a str) -> IResult<&'a str, Italic<'a>> {
+fn parse_italic<'a>(input: &'a str) -> IResult<&'a str, Italic> {
     todo!()
 }
 
-fn parse_strike<'a>(input: &'a str) -> IResult<&'a str, Strike<'a>> {
+fn parse_strike<'a>(input: &'a str) -> IResult<&'a str, Strike> {
     todo!()
 }
 
-fn parse_inline_code<'a>(input: &'a str) -> IResult<&'a str, InlineCode<'a>> {
+fn parse_inline_code<'a>(input: &'a str) -> IResult<&'a str, InlineCode> {
     todo!()
 }
 
-fn parse_math_inline<'a>(input: &'a str) -> IResult<&'a str, MathInline<'a>> {
+fn parse_math_inline<'a>(input: &'a str) -> IResult<&'a str, MathInline> {
     todo!()
 }
 
-fn parse_mention<'a>(input: &'a str) -> IResult<&'a str, Mention<'a>> {
+fn parse_mention<'a>(input: &'a str) -> IResult<&'a str, Mention> {
     todo!()
 }
 
-fn parse_hashtag<'a>(input: &'a str) -> IResult<&'a str, Hashtag<'a>> {
+fn parse_hashtag<'a>(input: &'a str) -> IResult<&'a str, Hashtag> {
     todo!()
 }
 
-fn parse_url<'a>(input: &'a str) -> IResult<&'a str, Url<'a>> {
+fn parse_url<'a>(input: &'a str) -> IResult<&'a str, Url> {
     todo!()
 }
 
-fn parse_link<'a>(input: &'a str) -> IResult<&'a str, Link<'a>> {
+fn parse_link<'a>(input: &'a str) -> IResult<&'a str, Link> {
     todo!()
 }
 
-fn parse_fn<'a>(input: &'a str) -> IResult<&'a str, Fn<'a>> {
+fn parse_fn<'a>(input: &'a str) -> IResult<&'a str, Fn> {
     todo!()
 }
 
-fn parse_plain<'a>(input: &'a str) -> IResult<&'a str, Plain<'a>> {
+fn parse_plain<'a>(input: &'a str) -> IResult<&'a str, Plain> {
     todo!()
 }
 
-fn parse_text<'a>(input: &'a str) -> IResult<&'a str, Text<'a>> {
+fn parse_text<'a>(input: &'a str) -> IResult<&'a str, Text> {
     todo!()
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,99 +1,209 @@
-use nom::{branch::alt, combinator::map, multi::many0, IResult};
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take},
+    character::complete::{anychar, char, line_ending, not_line_ending},
+    combinator::{map, map_res, not, opt, recognize, verify},
+    error::{ErrorKind, ParseError},
+    multi::{many0, many1, many_m_n, separated_list1},
+    sequence::{delimited, pair, preceded},
+    IResult,
+};
 
-use crate::node::*;
+use crate::{node::*, util::merge_text};
 
-pub fn parse<'a>(input: &'a str) -> IResult<&'a str, Vec<Node>> {
-    many0(alt((
-        map(parse_block, Node::Block),
-        map(parse_inline, Node::Inline),
-    )))(input)
+fn failure<'a>(input: &'a str) -> nom::error::Error<&'a str> {
+    nom::error::Error::from_error_kind(input, ErrorKind::Fail)
 }
 
-fn parse_block<'a>(input: &'a str) -> IResult<&'a str, Block> {
-    alt((
-        map(parse_quote, Block::Quote),
-        map(parse_search, Block::Search),
-        map(parse_code_block, Block::CodeBlock),
-        map(parse_math_block, Block::MathBlock),
-    ))(input)
+fn space<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &'a str, E> {
+    alt((tag("\u{0020}"), tag("\u{3000}"), tag("\t")))(input)
 }
 
-fn parse_quote<'a>(input: &'a str) -> IResult<&'a str, Quote> {
-    todo!()
+/// Parser for full MFM syntax.
+#[derive(Clone, Debug)]
+pub struct FullParser {
+    nest_limit: u32,
+    depth: u32,
 }
 
-fn parse_search<'a>(input: &'a str) -> IResult<&'a str, Search> {
-    todo!()
+impl Default for FullParser {
+    fn default() -> Self {
+        FullParser {
+            nest_limit: 20,
+            depth: 0,
+        }
+    }
 }
 
-fn parse_code_block<'a>(input: &'a str) -> IResult<&'a str, CodeBlock> {
-    todo!()
-}
+impl FullParser {
+    /// Creates a parser with nest limit.
+    pub fn new(nest_limit: u32) -> Self {
+        FullParser {
+            nest_limit,
+            depth: 0,
+        }
+    }
 
-fn parse_math_block<'a>(input: &'a str) -> IResult<&'a str, MathBlock> {
-    todo!()
-}
+    /// Returns a parser if its depth does not reach the nest limit.
+    fn nest(&self) -> Option<Self> {
+        let depth = self.depth + 1;
+        if depth < self.nest_limit {
+            Some(FullParser {
+                nest_limit: self.nest_limit,
+                depth,
+            })
+        } else {
+            None
+        }
+    }
 
-fn parse_inline<'a>(input: &'a str) -> IResult<&'a str, Inline> {
-    todo!()
-}
+    /// Returns a full MFM node tree.
+    pub fn parse<'a>(&self, input: &'a str) -> IResult<&'a str, Vec<Node>> {
+        map(
+            many0(alt((
+                map(|s| self.parse_block(s), Node::Block),
+                map(|s| self.parse_inline(s), Node::Inline),
+            ))),
+            merge_text,
+        )(input)
+    }
 
-fn parse_unicode_emoji<'a>(input: &'a str) -> IResult<&'a str, UnicodeEmoji> {
-    todo!()
-}
+    fn parse_block<'a>(&self, input: &'a str) -> IResult<&'a str, Block> {
+        alt((
+            map(|s| self.parse_quote(s), Block::Quote),
+            // map(Self::parse_search, Block::Search),
+            // map(Self::parse_code_block, Block::CodeBlock),
+            // map(Self::parse_math_block, Block::MathBlock),
+        ))(input)
+    }
 
-fn parse_emoji_code<'a>(input: &'a str) -> IResult<&'a str, EmojiCode> {
-    todo!()
-}
+    fn parse_quote<'a>(&self, input: &'a str) -> IResult<&'a str, Quote> {
+        delimited(
+            many_m_n(0, 2, line_ending),
+            map_res(
+                map(
+                    verify(
+                        separated_list1(
+                            line_ending,
+                            preceded(pair(char('>'), many0(space)), not_line_ending),
+                        ),
+                        // disallow empty content if single line
+                        |contents: &Vec<&str>| contents.len() > 1 || contents[0].len() != 0,
+                    ),
+                    |contents| contents.join("\n"),
+                ),
+                |contents| {
+                    // parse inner contents
+                    let nodes = if let Some(inner) = self.nest() {
+                        inner.parse(&contents).map_err(|_| failure(input))?.1
+                    } else {
+                        vec![Node::Inline(Inline::Text(Text { text: contents }))]
+                    };
+                    Ok::<Quote, nom::error::Error<&str>>(Quote(nodes))
+                },
+            ),
+            many_m_n(0, 2, line_ending),
+        )(input)
+    }
 
-fn parse_bold<'a>(input: &'a str) -> IResult<&'a str, Bold> {
-    todo!()
-}
+    fn parse_search<'a>(input: &'a str) -> IResult<&'a str, Search> {
+        todo!()
+    }
 
-fn parse_small<'a>(input: &'a str) -> IResult<&'a str, Small> {
-    todo!()
-}
+    fn parse_code_block<'a>(input: &'a str) -> IResult<&'a str, CodeBlock> {
+        todo!()
+    }
 
-fn parse_italic<'a>(input: &'a str) -> IResult<&'a str, Italic> {
-    todo!()
-}
+    fn parse_math_block<'a>(input: &'a str) -> IResult<&'a str, MathBlock> {
+        todo!()
+    }
 
-fn parse_strike<'a>(input: &'a str) -> IResult<&'a str, Strike> {
-    todo!()
-}
+    fn parse_inline<'a>(&self, input: &'a str) -> IResult<&'a str, Inline> {
+        alt((
+            map(Self::parse_plain, Inline::Plain),
+            map(Self::parse_text, Inline::Text),
+        ))(input)
+    }
 
-fn parse_inline_code<'a>(input: &'a str) -> IResult<&'a str, InlineCode> {
-    todo!()
-}
+    fn parse_unicode_emoji<'a>(input: &'a str) -> IResult<&'a str, UnicodeEmoji> {
+        todo!()
+    }
 
-fn parse_math_inline<'a>(input: &'a str) -> IResult<&'a str, MathInline> {
-    todo!()
-}
+    fn parse_emoji_code<'a>(input: &'a str) -> IResult<&'a str, EmojiCode> {
+        todo!()
+    }
 
-fn parse_mention<'a>(input: &'a str) -> IResult<&'a str, Mention> {
-    todo!()
-}
+    fn parse_bold<'a>(input: &'a str) -> IResult<&'a str, Bold> {
+        todo!()
+    }
 
-fn parse_hashtag<'a>(input: &'a str) -> IResult<&'a str, Hashtag> {
-    todo!()
-}
+    fn parse_small<'a>(input: &'a str) -> IResult<&'a str, Small> {
+        todo!()
+    }
 
-fn parse_url<'a>(input: &'a str) -> IResult<&'a str, Url> {
-    todo!()
-}
+    fn parse_italic<'a>(input: &'a str) -> IResult<&'a str, Italic> {
+        todo!()
+    }
 
-fn parse_link<'a>(input: &'a str) -> IResult<&'a str, Link> {
-    todo!()
-}
+    fn parse_strike<'a>(input: &'a str) -> IResult<&'a str, Strike> {
+        todo!()
+    }
 
-fn parse_fn<'a>(input: &'a str) -> IResult<&'a str, Fn> {
-    todo!()
-}
+    fn parse_inline_code<'a>(input: &'a str) -> IResult<&'a str, InlineCode> {
+        todo!()
+    }
 
-fn parse_plain<'a>(input: &'a str) -> IResult<&'a str, Plain> {
-    todo!()
-}
+    fn parse_math_inline<'a>(input: &'a str) -> IResult<&'a str, MathInline> {
+        todo!()
+    }
 
-fn parse_text<'a>(input: &'a str) -> IResult<&'a str, Text> {
-    todo!()
+    fn parse_mention<'a>(input: &'a str) -> IResult<&'a str, Mention> {
+        todo!()
+    }
+
+    fn parse_hashtag<'a>(input: &'a str) -> IResult<&'a str, Hashtag> {
+        todo!()
+    }
+
+    fn parse_url<'a>(input: &'a str) -> IResult<&'a str, Url> {
+        todo!()
+    }
+
+    fn parse_link<'a>(input: &'a str) -> IResult<&'a str, Link> {
+        todo!()
+    }
+
+    fn parse_fn<'a>(input: &'a str) -> IResult<&'a str, Fn> {
+        todo!()
+    }
+
+    fn parse_plain<'a>(input: &'a str) -> IResult<&'a str, Plain> {
+        const OPEN: &str = "<plain>";
+        const CLOSE: &str = "</plain>";
+        delimited(
+            tag(OPEN),
+            delimited(
+                opt(line_ending),
+                map(
+                    recognize(many1(preceded(
+                        not(pair(opt(line_ending), tag(CLOSE))),
+                        anychar,
+                    ))),
+                    |text: &str| {
+                        Plain(vec![Text {
+                            text: text.to_string(),
+                        }])
+                    },
+                ),
+                opt(line_ending),
+            ),
+            tag(CLOSE),
+        )(input)
+    }
+
+    fn parse_text<'a>(input: &'a str) -> IResult<&'a str, Text> {
+        map(take(1u8), |s: &str| Text {
+            text: s.to_string(),
+        })(input)
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use crate::node::{Inline, Node, Text};
+use crate::node::{Inline, Node, Simple, Text};
 
 /// Pushes text to vector if stored string is not empty.
 fn generate_text<T: From<Text>>(mut dest: Vec<T>, stored_string: String) -> (Vec<T>, String) {
@@ -37,6 +37,24 @@ pub fn merge_text_inline(nodes: Vec<Inline>) -> Vec<Inline> {
         (Vec::<Inline>::new(), String::new()),
         |(dest, stored_string), node| {
             if let Inline::Text(Text { text }) = node {
+                (dest, stored_string + &text)
+            } else {
+                let (mut dest, stored_string) = generate_text(dest, stored_string);
+                dest.push(node);
+                (dest, stored_string)
+            }
+        },
+    );
+
+    generate_text(dest, stored_string).0
+}
+
+/// Merges adjacent simple text nodes into one with their contents concatenated.
+pub fn merge_text_simple(nodes: Vec<Simple>) -> Vec<Simple> {
+    let (dest, stored_string) = nodes.into_iter().fold(
+        (Vec::<Simple>::new(), String::new()),
+        |(dest, stored_string), node| {
+            if let Simple::Text(Text { text }) = node {
                 (dest, stored_string + &text)
             } else {
                 let (mut dest, stored_string) = generate_text(dest, stored_string);

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,56 +13,68 @@ fn generate_text<T: From<Text>>(mut dest: Vec<T>, stored_string: String) -> (Vec
     }
 }
 
-/// Merges adjacent text nodes into one with their contents concatenated.
-pub fn merge_text(nodes: Vec<Node>) -> Vec<Node> {
-    let (dest, stored_string) = nodes.into_iter().fold(
-        (Vec::<Node>::new(), String::new()),
-        |(dest, stored_string), node| {
-            if let Node::Inline(Inline::Text(Text { text })) = node {
-                (dest, stored_string + &text)
-            } else {
-                let (mut dest, stored_string) = generate_text(dest, stored_string);
-                dest.push(node);
-                (dest, stored_string)
-            }
-        },
-    );
-
-    generate_text(dest, stored_string).0
+pub(crate) trait MergeText {
+    fn merge_text(nodes: Vec<Self>) -> Vec<Self>
+    where
+        Self: Sized;
 }
 
-/// Merges adjacent inline text nodes into one with their contents concatenated.
-pub fn merge_text_inline(nodes: Vec<Inline>) -> Vec<Inline> {
-    let (dest, stored_string) = nodes.into_iter().fold(
-        (Vec::<Inline>::new(), String::new()),
-        |(dest, stored_string), node| {
-            if let Inline::Text(Text { text }) = node {
-                (dest, stored_string + &text)
-            } else {
-                let (mut dest, stored_string) = generate_text(dest, stored_string);
-                dest.push(node);
-                (dest, stored_string)
-            }
-        },
-    );
+impl MergeText for Node {
+    /// Merges adjacent text nodes into one with their contents concatenated.
+    fn merge_text(nodes: Vec<Self>) -> Vec<Self> {
+        let (dest, stored_string) = nodes.into_iter().fold(
+            (Vec::<Self>::new(), String::new()),
+            |(dest, stored_string), node| {
+                if let Node::Inline(Inline::Text(Text { text })) = node {
+                    (dest, stored_string + &text)
+                } else {
+                    let (mut dest, stored_string) = generate_text(dest, stored_string);
+                    dest.push(node);
+                    (dest, stored_string)
+                }
+            },
+        );
 
-    generate_text(dest, stored_string).0
+        generate_text(dest, stored_string).0
+    }
 }
 
-/// Merges adjacent simple text nodes into one with their contents concatenated.
-pub fn merge_text_simple(nodes: Vec<Simple>) -> Vec<Simple> {
-    let (dest, stored_string) = nodes.into_iter().fold(
-        (Vec::<Simple>::new(), String::new()),
-        |(dest, stored_string), node| {
-            if let Simple::Text(Text { text }) = node {
-                (dest, stored_string + &text)
-            } else {
-                let (mut dest, stored_string) = generate_text(dest, stored_string);
-                dest.push(node);
-                (dest, stored_string)
-            }
-        },
-    );
+impl MergeText for Inline {
+    /// Merges adjacent text nodes into one with their contents concatenated.
+    fn merge_text(nodes: Vec<Self>) -> Vec<Self> {
+        let (dest, stored_string) = nodes.into_iter().fold(
+            (Vec::<Self>::new(), String::new()),
+            |(dest, stored_string), node| {
+                if let Inline::Text(Text { text }) = node {
+                    (dest, stored_string + &text)
+                } else {
+                    let (mut dest, stored_string) = generate_text(dest, stored_string);
+                    dest.push(node);
+                    (dest, stored_string)
+                }
+            },
+        );
 
-    generate_text(dest, stored_string).0
+        generate_text(dest, stored_string).0
+    }
+}
+
+impl MergeText for Simple {
+    /// Merges adjacent text nodes into one with their contents concatenated.
+    fn merge_text(nodes: Vec<Self>) -> Vec<Self> {
+        let (dest, stored_string) = nodes.into_iter().fold(
+            (Vec::<Self>::new(), String::new()),
+            |(dest, stored_string), node| {
+                if let Simple::Text(Text { text }) = node {
+                    (dest, stored_string + &text)
+                } else {
+                    let (mut dest, stored_string) = generate_text(dest, stored_string);
+                    dest.push(node);
+                    (dest, stored_string)
+                }
+            },
+        );
+
+        generate_text(dest, stored_string).0
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,12 +1,12 @@
 use crate::node::{Inline, Node, Text};
 
 /// Pushes text to vector if stored string is not empty.
-fn generate_text(mut dest: Vec<Node>, stored_string: String) -> (Vec<Node>, String) {
+fn generate_text<T: From<Text>>(mut dest: Vec<T>, stored_string: String) -> (Vec<T>, String) {
     if !stored_string.is_empty() {
-        let text = Node::Inline(Inline::Text(Text {
+        let text = Text {
             text: stored_string.clone(),
-        }));
-        dest.push(text);
+        };
+        dest.push(text.into());
         (dest, String::new())
     } else {
         (dest, stored_string)
@@ -17,9 +17,28 @@ fn generate_text(mut dest: Vec<Node>, stored_string: String) -> (Vec<Node>, Stri
 pub fn merge_text(nodes: Vec<Node>) -> Vec<Node> {
     let (dest, stored_string) = nodes.into_iter().fold(
         (Vec::<Node>::new(), String::new()),
-        |(dest, stored_string), node| match node {
-            Node::Inline(Inline::Text(Text { text })) => (dest, stored_string + &text),
-            _ => {
+        |(dest, stored_string), node| {
+            if let Node::Inline(Inline::Text(Text { text })) = node {
+                (dest, stored_string + &text)
+            } else {
+                let (mut dest, stored_string) = generate_text(dest, stored_string);
+                dest.push(node);
+                (dest, stored_string)
+            }
+        },
+    );
+
+    generate_text(dest, stored_string).0
+}
+
+/// Merges adjacent inline text nodes into one with their contents concatenated.
+pub fn merge_text_inline(nodes: Vec<Inline>) -> Vec<Inline> {
+    let (dest, stored_string) = nodes.into_iter().fold(
+        (Vec::<Inline>::new(), String::new()),
+        |(dest, stored_string), node| {
+            if let Inline::Text(Text { text }) = node {
+                (dest, stored_string + &text)
+            } else {
                 let (mut dest, stored_string) = generate_text(dest, stored_string);
                 dest.push(node);
                 (dest, stored_string)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,31 @@
+use crate::node::{Inline, Node, Text};
+
+/// Pushes text to vector if stored string is not empty.
+fn generate_text(mut dest: Vec<Node>, stored_string: String) -> (Vec<Node>, String) {
+    if !stored_string.is_empty() {
+        let text = Node::Inline(Inline::Text(Text {
+            text: stored_string.clone(),
+        }));
+        dest.push(text);
+        (dest, String::new())
+    } else {
+        (dest, stored_string)
+    }
+}
+
+/// Merges adjacent text nodes into one with their contents concatenated.
+pub fn merge_text(nodes: Vec<Node>) -> Vec<Node> {
+    let (dest, stored_string) = nodes.into_iter().fold(
+        (Vec::<Node>::new(), String::new()),
+        |(dest, stored_string), node| match node {
+            Node::Inline(Inline::Text(Text { text })) => (dest, stored_string + &text),
+            _ => {
+                let (mut dest, stored_string) = generate_text(dest, stored_string);
+                dest.push(node);
+                (dest, stored_string)
+            }
+        },
+    );
+
+    generate_text(dest, stored_string).0
+}

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -614,7 +614,6 @@ hoge"#;
             }
 
             #[test]
-            #[ignore]
             fn inline_contents() {
                 let input = "**123~~abc~~123**";
                 let output = vec![Node::Inline(Inline::Bold(Bold(vec![
@@ -632,7 +631,6 @@ hoge"#;
             }
 
             #[test]
-            #[ignore]
             fn multiple_line_contents() {
                 let input = "**123\n~~abc~~\n123**";
                 let output = vec![Node::Inline(Inline::Bold(Bold(vec![
@@ -663,7 +661,6 @@ hoge"#;
             }
 
             #[test]
-            #[ignore]
             fn inline_contents() {
                 let input = "<b>123~~abc~~123</b>";
                 let output = vec![Node::Inline(Inline::Bold(Bold(vec![
@@ -681,7 +678,6 @@ hoge"#;
             }
 
             #[test]
-            #[ignore]
             fn multiple_line_contents() {
                 let input = "<b>123\n~~abc~~\n123</b>";
                 let output = vec![Node::Inline(Inline::Bold(Bold(vec![
@@ -946,6 +942,49 @@ hoge"#;
         }
     }
 
+    mod strike {
+        use super::*;
+
+        mod tag {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = "<s>foo</s>";
+                let output = vec![Node::Inline(Inline::Strike(Strike(vec![Inline::Text(
+                    Text {
+                        text: "foo".to_string(),
+                    },
+                )])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+        }
+
+        mod wave {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = "~~foo~~";
+                let output = vec![Node::Inline(Inline::Strike(Strike(vec![Inline::Text(
+                    Text {
+                        text: "foo".to_string(),
+                    },
+                )])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn newline_between_marks() {
+                let input = "~~foo\nbar~~";
+                let output = vec![Node::Inline(Inline::Text(Text {
+                    text: "~~foo\nbar~~".to_string(),
+                }))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+        }
+    }
+
     mod plain {
         use super::*;
 
@@ -1070,6 +1109,32 @@ hoge"#;
                 })],
             ))])))];
             assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+        }
+
+        mod strike {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = "<b><b>~~abc~~</b></b>";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![Inline::Bold(Bold(
+                    vec![Inline::Text(Text {
+                        text: "~~abc~~".to_string(),
+                    })],
+                ))])))];
+                assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+            }
+
+            #[test]
+            fn tag() {
+                let input = "<b><b><s>abc</s></b></b>";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![Inline::Bold(Bold(
+                    vec![Inline::Text(Text {
+                        text: "<s>abc</s>".to_string(),
+                    })],
+                ))])))];
+                assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+            }
         }
     }
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -2132,6 +2132,117 @@ hoge"#;
         }
     }
 
+    mod fn_ {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let input = "$[tada abc]";
+            let output = vec![Node::Inline(Inline::Fn(Fn {
+                name: "tada".to_string(),
+                args: Vec::new(),
+                children: vec![Inline::Text(Text {
+                    text: "abc".to_string(),
+                })],
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_a_string_argument() {
+            let input = "$[spin.speed=1.1s a]";
+            let output = vec![Node::Inline(Inline::Fn(Fn {
+                name: "spin".to_string(),
+                args: vec![("speed".to_string(), Some("1.1s".to_string()))],
+                children: vec![Inline::Text(Text {
+                    text: "a".to_string(),
+                })],
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_a_string_argument_2() {
+            let input = "$[position.x=-3 a]";
+            let output = vec![Node::Inline(Inline::Fn(Fn {
+                name: "position".to_string(),
+                args: vec![("x".to_string(), Some("-3".to_string()))],
+                children: vec![Inline::Text(Text {
+                    text: "a".to_string(),
+                })],
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_multiple_string_arguments() {
+            let input = "$[scale.x=3,y=4 a]";
+            let output = vec![Node::Inline(Inline::Fn(Fn {
+                name: "scale".to_string(),
+                args: vec![
+                    ("x".to_string(), Some("3".to_string())),
+                    ("y".to_string(), Some("4".to_string())),
+                ],
+                children: vec![Inline::Text(Text {
+                    text: "a".to_string(),
+                })],
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_a_argument_without_value() {
+            let input = "$[font.serif a]";
+            let output = vec![Node::Inline(Inline::Fn(Fn {
+                name: "font".to_string(),
+                args: vec![("serif".to_string(), None)],
+                children: vec![Inline::Text(Text {
+                    text: "a".to_string(),
+                })],
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_multiple_arguments_without_value() {
+            let input = "$[flip.h,v a]";
+            let output = vec![Node::Inline(Inline::Fn(Fn {
+                name: "flip".to_string(),
+                args: vec![("h".to_string(), None), ("v".to_string(), None)],
+                children: vec![Inline::Text(Text {
+                    text: "a".to_string(),
+                })],
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn invalid_fn_name() {
+            let input = "$[関数 text]";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "$[関数 text]".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn nest() {
+            let input = "$[spin.speed=1.1s $[shake a]]";
+            let output = vec![Node::Inline(Inline::Fn(Fn {
+                name: "spin".to_string(),
+                args: vec![("speed".to_string(), Some("1.1s".to_string()))],
+                children: vec![Inline::Fn(Fn {
+                    name: "shake".to_string(),
+                    args: Vec::new(),
+                    children: vec![Inline::Text(Text {
+                        text: "a".to_string(),
+                    })],
+                })],
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
     mod plain {
         use super::*;
 
@@ -2397,6 +2508,17 @@ hoge"#;
                     text: "(x(y)z)".to_string(),
                 }),
             ])))];
+            assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+        }
+
+        #[test]
+        fn fn_() {
+            let input = "<b><b>$[a b]</b></b>";
+            let output = vec![Node::Inline(Inline::Bold(Bold(vec![Inline::Bold(Bold(
+                vec![Inline::Text(Text {
+                    text: "$[a b]".to_string(),
+                })],
+            ))])))];
             assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
         }
     }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -985,6 +985,37 @@ hoge"#;
         }
     }
 
+    mod inline_code {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let input = r#"`var x = "Strawberry Pasta";`"#;
+            let output = vec![Node::Inline(Inline::InlineCode(InlineCode {
+                code: r#"var x = "Strawberry Pasta";"#.to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn disallow_line_break() {
+            let input = "`foo\nbar`";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "`foo\nbar`".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn disallow_acute_accent() {
+            let input = "`foo´bar`";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "`foo´bar`".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
     mod plain {
         use super::*;
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,460 +1,565 @@
 use mfm::node::*;
 
-mod text {
+mod simple_parser {
     use super::*;
 
-    #[test]
-    fn basic() {
-        let input = "abc";
-        let output = vec![Node::Inline(Inline::Text(Text {
-            text: "abc".to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-}
+    mod text {
+        use super::*;
 
-mod quote {
-    use super::*;
-
-    #[test]
-    fn single_line() {
-        let input = "> abc";
-        let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Inline(
-            Inline::Text(Text {
+        #[test]
+        fn basic() {
+            let input = "abc";
+            let output = vec![Simple::Text(Text {
                 text: "abc".to_string(),
-            }),
-        )])))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
+            })];
+            assert_eq!(mfm::parse_simple(input).unwrap(), output);
+        }
 
-    #[test]
-    fn multiple_line() {
-        let input = r#"
-> abc
-> 123
-"#;
-        let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Inline(
-            Inline::Text(Text {
-                text: "abc\n123".to_string(),
-            }),
-        )])))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
+        #[test]
+        fn ignore_hashtag() {
+            let input = "abc#abc";
+            let output = vec![Simple::Text(Text {
+                text: "abc#abc".to_string(),
+            })];
+            assert_eq!(mfm::parse_simple(input).unwrap(), output);
+        }
 
-    #[test]
-    fn nest_block() {
-        let input = r#"
-> <center>
-> a
-> </center>
-"#;
-        let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
-            Block::Center(Center(vec![Inline::Text(Text {
-                text: "a".to_string(),
-            })])),
-        )])))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    #[ignore]
-    fn nest_block_with_inline() {
-        let input = r#"
-> <center>
-> I'm @ai, An bot of misskey!
-> </center>
-"#;
-        let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
-            Block::Center(Center(vec![
-                Inline::Text(Text {
-                    text: "I'm ".to_string(),
+        #[test]
+        #[ignore]
+        fn keycap_number_sign() {
+            let input = "abc#️⃣abc";
+            let output = vec![
+                Simple::Text(Text {
+                    text: "abc".to_string(),
                 }),
-                Inline::Mention(Mention {
-                    username: "ai".to_string(),
-                    host: None,
-                    acct: "@ai".to_string(),
+                Simple::UnicodeEmoji(UnicodeEmoji {
+                    emoji: "#️⃣".to_string(),
                 }),
-                Inline::Text(Text {
-                    text: ", An bot of misskey!".to_string(),
+                Simple::Text(Text {
+                    text: "abc".to_string(),
                 }),
-            ])),
-        )])))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
+            ];
+            assert_eq!(mfm::parse_simple(input).unwrap(), output);
+        }
+    }
+
+    mod emoji {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let input = ":foo:";
+            let output = vec![Simple::EmojiCode(EmojiCode {
+                name: "foo".to_string(),
+            })];
+            assert_eq!(mfm::parse_simple(input).unwrap(), output);
+        }
+
+        #[test]
+        fn between_texts() {
+            let input = "foo:bar:baz";
+            let output = vec![Simple::Text(Text {
+                text: "foo:bar:baz".to_string(),
+            })];
+            assert_eq!(mfm::parse_simple(input).unwrap(), output);
+        }
+
+        #[test]
+        fn between_texts_2() {
+            let input = "12:34:56";
+            let output = vec![Simple::Text(Text {
+                text: "12:34:56".to_string(),
+            })];
+            assert_eq!(mfm::parse_simple(input).unwrap(), output);
+        }
+
+        #[test]
+        fn between_texts_3() {
+            let input = "あ:bar:い";
+            let output = vec![
+                Simple::Text(Text {
+                    text: "あ".to_string(),
+                }),
+                Simple::EmojiCode(EmojiCode {
+                    name: "bar".to_string(),
+                }),
+                Simple::Text(Text {
+                    text: "い".to_string(),
+                }),
+            ];
+            assert_eq!(mfm::parse_simple(input).unwrap(), output);
+        }
     }
 
     #[test]
-    fn multiple_line_with_empty_line() {
-        let input = r#"
-> abc
->
-> 123
-"#;
-        let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Inline(
-            Inline::Text(Text {
-                text: "abc\n\n123".to_string(),
-            }),
-        )])))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn single_empty_line() {
-        let input = "> ";
-        let output = vec![Node::Inline(Inline::Text(Text {
-            text: "> ".to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn ignore_empty_line_after_quote() {
-        let input = r#"
-> foo
-> bar
-
-hoge"#;
-        let output = vec![
-            Node::Block(Block::Quote(Quote(vec![Node::Inline(Inline::Text(
-                Text {
-                    text: "foo\nbar".to_string(),
-                },
-            ))]))),
-            Node::Inline(Inline::Text(Text {
-                text: "hoge".to_string(),
-            })),
-        ];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn two_quote_blocks() {
-        let input = r#"
-> foo
-
-> bar
-
-hoge"#;
-        let output = vec![
-            Node::Block(Block::Quote(Quote(vec![Node::Inline(Inline::Text(
-                Text {
-                    text: "foo".to_string(),
-                },
-            ))]))),
-            Node::Block(Block::Quote(Quote(vec![Node::Inline(Inline::Text(
-                Text {
-                    text: "bar".to_string(),
-                },
-            ))]))),
-            Node::Inline(Inline::Text(Text {
-                text: "hoge".to_string(),
-            })),
-        ];
-        assert_eq!(mfm::parse(input).unwrap(), output);
+    fn disallow_other_syntaxes() {
+        let input = "foo **bar** baz";
+        let output = vec![Simple::Text(Text {
+            text: "foo **bar** baz".to_string(),
+        })];
+        assert_eq!(mfm::parse_simple(input).unwrap(), output);
     }
 }
 
-mod search {
+mod full_parser {
     use super::*;
 
-    #[test]
-    fn basic() {
-        let input = "MFM 書き方 123 Search";
-        let output = vec![Node::Block(Block::Search(Search {
-            query: "MFM 書き方 123".to_string(),
-            content: input.to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
+    mod text {
+        use super::*;
 
-        let input = "MFM 書き方 123 [Search]";
-        let output = vec![Node::Block(Block::Search(Search {
-            query: "MFM 書き方 123".to_string(),
-            content: input.to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-
-        let input = "MFM 書き方 123 search";
-        let output = vec![Node::Block(Block::Search(Search {
-            query: "MFM 書き方 123".to_string(),
-            content: input.to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-
-        let input = "MFM 書き方 123 [search]";
-        let output = vec![Node::Block(Block::Search(Search {
-            query: "MFM 書き方 123".to_string(),
-            content: input.to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-
-        let input = "MFM 書き方 123 検索";
-        let output = vec![Node::Block(Block::Search(Search {
-            query: "MFM 書き方 123".to_string(),
-            content: input.to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-
-        let input = "MFM 書き方 123 [検索]";
-        let output = vec![Node::Block(Block::Search(Search {
-            query: "MFM 書き方 123".to_string(),
-            content: input.to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn text_around_block() {
-        let input = "abc\nhoge piyo bebeyo 検索\n123";
-        let output = vec![
-            Node::Inline(Inline::Text(Text {
+        #[test]
+        fn basic() {
+            let input = "abc";
+            let output = vec![Node::Inline(Inline::Text(Text {
                 text: "abc".to_string(),
-            })),
-            Node::Block(Block::Search(Search {
-                query: "hoge piyo bebeyo".to_string(),
-                content: "hoge piyo bebeyo 検索".to_string(),
-            })),
-            Node::Inline(Inline::Text(Text {
-                text: "123".to_string(),
-            })),
-        ];
-        assert_eq!(mfm::parse(input).unwrap(), output);
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
     }
-}
-
-mod code_block {
-    use super::*;
-
-    #[test]
-    fn simple() {
-        let input = "```\nabc\n```";
-        let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
-            code: "abc".to_string(),
-            lang: None,
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn multiple_line() {
-        let input = "```\na\nb\nc\n```";
-        let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
-            code: "a\nb\nc".to_string(),
-            lang: None,
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn lang() {
-        let input = "```js\nconst a = 1;\n```";
-        let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
-            code: "const a = 1;".to_string(),
-            lang: Some("js".to_string()),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn text_around_block() {
-        let input = "abc\n```\nconst abc = 1;\n```\n123";
-        let output = vec![
-            Node::Inline(Inline::Text(Text {
-                text: "abc".to_string(),
-            })),
-            Node::Block(Block::CodeBlock(CodeBlock {
-                code: "const abc = 1;".to_string(),
-                lang: None,
-            })),
-            Node::Inline(Inline::Text(Text {
-                text: "123".to_string(),
-            })),
-        ];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn ignore_internal_marker() {
-        let input = "```\naaa```bbb\n```";
-        let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
-            code: "aaa```bbb".to_string(),
-            lang: None,
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn trim_after_line_break() {
-        let input = "```\nfoo\n```\nbar";
-        let output = vec![
-            Node::Block(Block::CodeBlock(CodeBlock {
-                code: "foo".to_string(),
-                lang: None,
-            })),
-            Node::Inline(Inline::Text(Text {
-                text: "bar".to_string(),
-            })),
-        ];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-}
-
-mod math_block {
-    use super::*;
-
-    #[test]
-    fn oneline() {
-        let input = "\\[math1\\]";
-        let output = vec![Node::Block(Block::MathBlock(MathBlock {
-            formula: "math1".to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn text_around_block() {
-        let input = "abc\n\\[math1\\]\n123";
-        let output = vec![
-            Node::Inline(Inline::Text(Text {
-                text: "abc".to_string(),
-            })),
-            Node::Block(Block::MathBlock(MathBlock {
-                formula: "math1".to_string(),
-            })),
-            Node::Inline(Inline::Text(Text {
-                text: "123".to_string(),
-            })),
-        ];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn close_tag_not_on_line_ending() {
-        let input = "\\[aaa\\]after";
-        let output = vec![Node::Inline(Inline::Text(Text {
-            text: "\\[aaa\\]after".to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    #[ignore]
-    fn open_tag_not_on_line_beginning() {
-        let input = "before\\[aaa\\]";
-        let output = vec![Node::Inline(Inline::Text(Text {
-            text: "before\\[aaa\\]".to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-}
-
-mod center {
-    use super::*;
-
-    #[test]
-    fn single_text() {
-        let input = "<center>abc</center>";
-        let output = vec![Node::Block(Block::Center(Center(vec![Inline::Text(
-            Text {
-                text: "abc".to_string(),
-            },
-        )])))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-
-    #[test]
-    fn multiple_text() {
-        let input = "before\n<center>\nabc\n123\n\npiyo\n</center>\nafter";
-        let output = vec![
-            Node::Inline(Inline::Text(Text {
-                text: "before".to_string(),
-            })),
-            Node::Block(Block::Center(Center(vec![Inline::Text(Text {
-                text: "abc\n123\n\npiyo".to_string(),
-            })]))),
-            Node::Inline(Inline::Text(Text {
-                text: "after".to_string(),
-            })),
-        ];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-}
-
-mod emoji_code {
-    use super::*;
-
-    #[test]
-    fn basic() {
-        let input = ":abc:";
-        let output = vec![Node::Inline(Inline::EmojiCode(EmojiCode {
-            name: "abc".to_string(),
-        }))];
-        assert_eq!(mfm::parse(input).unwrap(), output);
-    }
-}
-
-mod plain {
-    use super::*;
-
-    #[test]
-    fn multiple_line() {
-        let input = "a\n<plain>\n**Hello**\nworld\n</plain>\nb";
-        let output = vec![
-            Node::Inline(Inline::Text(Text {
-                text: "a\n".to_string(),
-            })),
-            Node::Inline(Inline::Plain(Plain(vec![Text {
-                text: "**Hello**\nworld".to_string(),
-            }]))),
-            Node::Inline(Inline::Text(Text {
-                text: "\nb".to_string(),
-            })),
-        ];
-        assert_eq!(mfm::parse(input).unwrap(), output)
-    }
-
-    #[test]
-    fn single_line() {
-        let input = "a\n<plain>\n**Hello** world\n</plain>\nb";
-        let output = vec![
-            Node::Inline(Inline::Text(Text {
-                text: "a\n".to_string(),
-            })),
-            Node::Inline(Inline::Plain(Plain(vec![Text {
-                text: "**Hello** world".to_string(),
-            }]))),
-            Node::Inline(Inline::Text(Text {
-                text: "\nb".to_string(),
-            })),
-        ];
-        assert_eq!(mfm::parse(input).unwrap(), output)
-    }
-}
-
-mod nesting_limit {
-    use super::*;
 
     mod quote {
         use super::*;
 
         #[test]
-        fn basic() {
-            let input = ">>> abc";
-            let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
-                Block::Quote(Quote(vec![Node::Inline(Inline::Text(Text {
-                    text: "> abc".to_string(),
-                }))])),
+        fn single_line() {
+            let input = "> abc";
+            let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Inline(
+                Inline::Text(Text {
+                    text: "abc".to_string(),
+                }),
             )])))];
-            assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+            assert_eq!(mfm::parse(input).unwrap(), output);
         }
 
         #[test]
-        fn basic2() {
-            let input = ">> **abc**";
-            let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
-                Block::Quote(Quote(vec![Node::Inline(Inline::Text(Text {
-                    text: "**abc**".to_string(),
-                }))])),
+        fn multiple_line() {
+            let input = r#"
+> abc
+> 123
+"#;
+            let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Inline(
+                Inline::Text(Text {
+                    text: "abc\n123".to_string(),
+                }),
             )])))];
-            assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn nest_block() {
+            let input = r#"
+> <center>
+> a
+> </center>
+"#;
+            let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
+                Block::Center(Center(vec![Inline::Text(Text {
+                    text: "a".to_string(),
+                })])),
+            )])))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        #[ignore]
+        fn nest_block_with_inline() {
+            let input = r#"
+> <center>
+> I'm @ai, An bot of misskey!
+> </center>
+"#;
+            let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
+                Block::Center(Center(vec![
+                    Inline::Text(Text {
+                        text: "I'm ".to_string(),
+                    }),
+                    Inline::Mention(Mention {
+                        username: "ai".to_string(),
+                        host: None,
+                        acct: "@ai".to_string(),
+                    }),
+                    Inline::Text(Text {
+                        text: ", An bot of misskey!".to_string(),
+                    }),
+                ])),
+            )])))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn multiple_line_with_empty_line() {
+            let input = r#"
+> abc
+>
+> 123
+"#;
+            let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Inline(
+                Inline::Text(Text {
+                    text: "abc\n\n123".to_string(),
+                }),
+            )])))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn single_empty_line() {
+            let input = "> ";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "> ".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn ignore_empty_line_after_quote() {
+            let input = r#"
+> foo
+> bar
+
+hoge"#;
+            let output = vec![
+                Node::Block(Block::Quote(Quote(vec![Node::Inline(Inline::Text(
+                    Text {
+                        text: "foo\nbar".to_string(),
+                    },
+                ))]))),
+                Node::Inline(Inline::Text(Text {
+                    text: "hoge".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn two_quote_blocks() {
+            let input = r#"
+> foo
+
+> bar
+
+hoge"#;
+            let output = vec![
+                Node::Block(Block::Quote(Quote(vec![Node::Inline(Inline::Text(
+                    Text {
+                        text: "foo".to_string(),
+                    },
+                ))]))),
+                Node::Block(Block::Quote(Quote(vec![Node::Inline(Inline::Text(
+                    Text {
+                        text: "bar".to_string(),
+                    },
+                ))]))),
+                Node::Inline(Inline::Text(Text {
+                    text: "hoge".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
+    mod search {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let input = "MFM 書き方 123 Search";
+            let output = vec![Node::Block(Block::Search(Search {
+                query: "MFM 書き方 123".to_string(),
+                content: input.to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+
+            let input = "MFM 書き方 123 [Search]";
+            let output = vec![Node::Block(Block::Search(Search {
+                query: "MFM 書き方 123".to_string(),
+                content: input.to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+
+            let input = "MFM 書き方 123 search";
+            let output = vec![Node::Block(Block::Search(Search {
+                query: "MFM 書き方 123".to_string(),
+                content: input.to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+
+            let input = "MFM 書き方 123 [search]";
+            let output = vec![Node::Block(Block::Search(Search {
+                query: "MFM 書き方 123".to_string(),
+                content: input.to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+
+            let input = "MFM 書き方 123 検索";
+            let output = vec![Node::Block(Block::Search(Search {
+                query: "MFM 書き方 123".to_string(),
+                content: input.to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+
+            let input = "MFM 書き方 123 [検索]";
+            let output = vec![Node::Block(Block::Search(Search {
+                query: "MFM 書き方 123".to_string(),
+                content: input.to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn text_around_block() {
+            let input = "abc\nhoge piyo bebeyo 検索\n123";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "abc".to_string(),
+                })),
+                Node::Block(Block::Search(Search {
+                    query: "hoge piyo bebeyo".to_string(),
+                    content: "hoge piyo bebeyo 検索".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "123".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
+    mod code_block {
+        use super::*;
+
+        #[test]
+        fn simple() {
+            let input = "```\nabc\n```";
+            let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
+                code: "abc".to_string(),
+                lang: None,
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn multiple_line() {
+            let input = "```\na\nb\nc\n```";
+            let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
+                code: "a\nb\nc".to_string(),
+                lang: None,
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn lang() {
+            let input = "```js\nconst a = 1;\n```";
+            let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
+                code: "const a = 1;".to_string(),
+                lang: Some("js".to_string()),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn text_around_block() {
+            let input = "abc\n```\nconst abc = 1;\n```\n123";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "abc".to_string(),
+                })),
+                Node::Block(Block::CodeBlock(CodeBlock {
+                    code: "const abc = 1;".to_string(),
+                    lang: None,
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "123".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn ignore_internal_marker() {
+            let input = "```\naaa```bbb\n```";
+            let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
+                code: "aaa```bbb".to_string(),
+                lang: None,
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn trim_after_line_break() {
+            let input = "```\nfoo\n```\nbar";
+            let output = vec![
+                Node::Block(Block::CodeBlock(CodeBlock {
+                    code: "foo".to_string(),
+                    lang: None,
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "bar".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
+    mod math_block {
+        use super::*;
+
+        #[test]
+        fn oneline() {
+            let input = "\\[math1\\]";
+            let output = vec![Node::Block(Block::MathBlock(MathBlock {
+                formula: "math1".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn text_around_block() {
+            let input = "abc\n\\[math1\\]\n123";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "abc".to_string(),
+                })),
+                Node::Block(Block::MathBlock(MathBlock {
+                    formula: "math1".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "123".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn close_tag_not_on_line_ending() {
+            let input = "\\[aaa\\]after";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "\\[aaa\\]after".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        #[ignore]
+        fn open_tag_not_on_line_beginning() {
+            let input = "before\\[aaa\\]";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "before\\[aaa\\]".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
+    mod center {
+        use super::*;
+
+        #[test]
+        fn single_text() {
+            let input = "<center>abc</center>";
+            let output = vec![Node::Block(Block::Center(Center(vec![Inline::Text(
+                Text {
+                    text: "abc".to_string(),
+                },
+            )])))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn multiple_text() {
+            let input = "before\n<center>\nabc\n123\n\npiyo\n</center>\nafter";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "before".to_string(),
+                })),
+                Node::Block(Block::Center(Center(vec![Inline::Text(Text {
+                    text: "abc\n123\n\npiyo".to_string(),
+                })]))),
+                Node::Inline(Inline::Text(Text {
+                    text: "after".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
+    mod emoji_code {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let input = ":abc:";
+            let output = vec![Node::Inline(Inline::EmojiCode(EmojiCode {
+                name: "abc".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
+    mod plain {
+        use super::*;
+
+        #[test]
+        fn multiple_line() {
+            let input = "a\n<plain>\n**Hello**\nworld\n</plain>\nb";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "a\n".to_string(),
+                })),
+                Node::Inline(Inline::Plain(Plain(vec![Text {
+                    text: "**Hello**\nworld".to_string(),
+                }]))),
+                Node::Inline(Inline::Text(Text {
+                    text: "\nb".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output)
+        }
+
+        #[test]
+        fn single_line() {
+            let input = "a\n<plain>\n**Hello** world\n</plain>\nb";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "a\n".to_string(),
+                })),
+                Node::Inline(Inline::Plain(Plain(vec![Text {
+                    text: "**Hello** world".to_string(),
+                }]))),
+                Node::Inline(Inline::Text(Text {
+                    text: "\nb".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output)
+        }
+    }
+
+    mod nesting_limit {
+        use super::*;
+
+        mod quote {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = ">>> abc";
+                let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
+                    Block::Quote(Quote(vec![Node::Inline(Inline::Text(Text {
+                        text: "> abc".to_string(),
+                    }))])),
+                )])))];
+                assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+            }
+
+            #[test]
+            fn basic2() {
+                let input = ">> **abc**";
+                let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
+                    Block::Quote(Quote(vec![Node::Inline(Inline::Text(Text {
+                        text: "**abc**".to_string(),
+                    }))])),
+                )])))];
+                assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+            }
         }
     }
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1284,6 +1284,383 @@ hoge"#;
         }
     }
 
+    mod hashtag {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let input = "#abc";
+            let output = vec![Node::Inline(Inline::Hashtag(Hashtag {
+                hashtag: "abc".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn basic_2() {
+            let input = "before #abc after";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "before ".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "abc".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: " after".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        #[ignore]
+        fn with_keycap_number_sign() {
+            let input = "#️⃣abc123 #abc";
+            let output = vec![
+                Node::Inline(Inline::UnicodeEmoji(UnicodeEmoji {
+                    emoji: "#️⃣".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "abc123 ".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "abc".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        #[ignore]
+        fn with_keycap_number_sign_2() {
+            let input = "abc\n#️⃣abc";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "abc\n".to_string(),
+                })),
+                Node::Inline(Inline::UnicodeEmoji(UnicodeEmoji {
+                    emoji: "#️⃣".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "abc".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn alnum_before_hashtag() {
+            let input = "abc#abc";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "abc#abc".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+
+            let input = "あいう#abc";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "あいう".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "abc".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn ignore_comma_and_period() {
+            let input = "Foo #bar, baz #piyo.";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "Foo ".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "bar".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: ", baz ".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "piyo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: ".".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn ignore_exclamation_mark() {
+            let input = "#Foo!";
+            let output = vec![
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "Foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "!".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn ignore_colon() {
+            let input = "#Foo:";
+            let output = vec![
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "Foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: ":".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn ignore_single_quote() {
+            let input = "#Foo'";
+            let output = vec![
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "Foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "'".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn ignore_double_quote() {
+            let input = "#Foo\"";
+            let output = vec![
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "Foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "\"".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn ignore_square_bracket() {
+            let input = "#Foo]";
+            let output = vec![
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "Foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "]".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn ignore_slash() {
+            let input = "#foo/bar";
+            let output = vec![
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "/bar".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn ignore_angle_bracket() {
+            let input = "#foo<bar>";
+            let output = vec![
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "<bar>".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn allow_including_number() {
+            let input = "#foo123";
+            let output = vec![Node::Inline(Inline::Hashtag(Hashtag {
+                hashtag: "foo123".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_parens() {
+            let input = "(#foo)";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "(".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: ")".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+
+            let input = "#(foo)";
+            let output = vec![Node::Inline(Inline::Hashtag(Hashtag {
+                hashtag: "(foo)".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_brackets() {
+            let input = "[#foo]";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "[".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "]".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+
+            let input = "#[foo]";
+            let output = vec![Node::Inline(Inline::Hashtag(Hashtag {
+                hashtag: "[foo]".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_fullwidth_parens() {
+            let input = "（#foo）";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "（".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "）".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+
+            let input = "#（foo）";
+            let output = vec![Node::Inline(Inline::Hashtag(Hashtag {
+                hashtag: "（foo）".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_corner_brackets() {
+            let input = "「#foo」";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "「".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "」".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+
+            let input = "#「foo」";
+            let output = vec![Node::Inline(Inline::Hashtag(Hashtag {
+                hashtag: "「foo」".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_mixed_brackets() {
+            let input = "「#foo(bar)」";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "「".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "foo(bar)".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "」".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_parens_space_before() {
+            let input = "(bar #foo)";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "(bar ".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: ")".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn with_square_brackets_space_before() {
+            let input = "「bar #foo」";
+            let output = vec![
+                Node::Inline(Inline::Text(Text {
+                    text: "「bar ".to_string(),
+                })),
+                Node::Inline(Inline::Hashtag(Hashtag {
+                    hashtag: "foo".to_string(),
+                })),
+                Node::Inline(Inline::Text(Text {
+                    text: "」".to_string(),
+                })),
+            ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn disallow_number_only() {
+            let input = "#123";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "#123".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn disallow_number_only_with_parens() {
+            let input = "(#123)";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "(#123)".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
     mod plain {
         use super::*;
 
@@ -1433,6 +1810,100 @@ hoge"#;
                     })],
                 ))])))];
                 assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+            }
+        }
+
+        mod hashtag {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = "<b>#abc(xyz)</b>";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![Inline::Hashtag(
+                    Hashtag {
+                        hashtag: "abc(xyz)".to_string(),
+                    },
+                )])))];
+                assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+
+                let input = "<b>#abc(x(y)z)</b>";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![
+                    Inline::Hashtag(Hashtag {
+                        hashtag: "abc".to_string(),
+                    }),
+                    Inline::Text(Text {
+                        text: "(x(y)z)".to_string(),
+                    }),
+                ])))];
+                assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+            }
+
+            #[test]
+            fn outside_parens() {
+                let input = "(#abc)";
+                let output = vec![
+                    Node::Inline(Inline::Text(Text {
+                        text: "(".to_string(),
+                    })),
+                    Node::Inline(Inline::Hashtag(Hashtag {
+                        hashtag: "abc".to_string(),
+                    })),
+                    Node::Inline(Inline::Text(Text {
+                        text: ")".to_string(),
+                    })),
+                ];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn outside_brackets() {
+                let input = "[#abc]";
+                let output = vec![
+                    Node::Inline(Inline::Text(Text {
+                        text: "[".to_string(),
+                    })),
+                    Node::Inline(Inline::Hashtag(Hashtag {
+                        hashtag: "abc".to_string(),
+                    })),
+                    Node::Inline(Inline::Text(Text {
+                        text: "]".to_string(),
+                    })),
+                ];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn outside_corner_brackets() {
+                let input = "「#abc」";
+                let output = vec![
+                    Node::Inline(Inline::Text(Text {
+                        text: "「".to_string(),
+                    })),
+                    Node::Inline(Inline::Hashtag(Hashtag {
+                        hashtag: "abc".to_string(),
+                    })),
+                    Node::Inline(Inline::Text(Text {
+                        text: "」".to_string(),
+                    })),
+                ];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn outside_fullwidth_parens() {
+                let input = "（#abc）";
+                let output = vec![
+                    Node::Inline(Inline::Text(Text {
+                        text: "（".to_string(),
+                    })),
+                    Node::Inline(Inline::Hashtag(Hashtag {
+                        hashtag: "abc".to_string(),
+                    })),
+                    Node::Inline(Inline::Text(Text {
+                        text: "）".to_string(),
+                    })),
+                ];
+                assert_eq!(mfm::parse(input).unwrap(), output);
             }
         }
     }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -378,6 +378,19 @@ mod center {
     }
 }
 
+mod emoji_code {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let input = ":abc:";
+        let output = vec![Node::Inline(Inline::EmojiCode(EmojiCode {
+            name: "abc".to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+}
+
 mod plain {
     use super::*;
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -221,6 +221,83 @@ mod search {
     }
 }
 
+mod code_block {
+    use super::*;
+
+    #[test]
+    fn simple() {
+        let input = "```\nabc\n```";
+        let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
+            code: "abc".to_string(),
+            lang: None,
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn multiple_line() {
+        let input = "```\na\nb\nc\n```";
+        let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
+            code: "a\nb\nc".to_string(),
+            lang: None,
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn lang() {
+        let input = "```js\nconst a = 1;\n```";
+        let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
+            code: "const a = 1;".to_string(),
+            lang: Some("js".to_string()),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn text_around_block() {
+        let input = "abc\n```\nconst abc = 1;\n```\n123";
+        let output = vec![
+            Node::Inline(Inline::Text(Text {
+                text: "abc".to_string(),
+            })),
+            Node::Block(Block::CodeBlock(CodeBlock {
+                code: "const abc = 1;".to_string(),
+                lang: None,
+            })),
+            Node::Inline(Inline::Text(Text {
+                text: "123".to_string(),
+            })),
+        ];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn ignore_internal_marker() {
+        let input = "```\naaa```bbb\n```";
+        let output = vec![Node::Block(Block::CodeBlock(CodeBlock {
+            code: "aaa```bbb".to_string(),
+            lang: None,
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn trim_after_line_break() {
+        let input = "```\nfoo\n```\nbar";
+        let output = vec![
+            Node::Block(Block::CodeBlock(CodeBlock {
+                code: "foo".to_string(),
+                lang: None,
+            })),
+            Node::Inline(Inline::Text(Text {
+                text: "bar".to_string(),
+            })),
+        ];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+}
+
 mod plain {
     use super::*;
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -154,6 +154,73 @@ hoge"#;
     }
 }
 
+mod search {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let input = "MFM 書き方 123 Search";
+        let output = vec![Node::Block(Block::Search(Search {
+            query: "MFM 書き方 123".to_string(),
+            content: input.to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+
+        let input = "MFM 書き方 123 [Search]";
+        let output = vec![Node::Block(Block::Search(Search {
+            query: "MFM 書き方 123".to_string(),
+            content: input.to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+
+        let input = "MFM 書き方 123 search";
+        let output = vec![Node::Block(Block::Search(Search {
+            query: "MFM 書き方 123".to_string(),
+            content: input.to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+
+        let input = "MFM 書き方 123 [search]";
+        let output = vec![Node::Block(Block::Search(Search {
+            query: "MFM 書き方 123".to_string(),
+            content: input.to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+
+        let input = "MFM 書き方 123 検索";
+        let output = vec![Node::Block(Block::Search(Search {
+            query: "MFM 書き方 123".to_string(),
+            content: input.to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+
+        let input = "MFM 書き方 123 [検索]";
+        let output = vec![Node::Block(Block::Search(Search {
+            query: "MFM 書き方 123".to_string(),
+            content: input.to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn text_around_block() {
+        let input = "abc\nhoge piyo bebeyo 検索\n123";
+        let output = vec![
+            Node::Inline(Inline::Text(Text {
+                text: "abc".to_string(),
+            })),
+            Node::Block(Block::Search(Search {
+                query: "hoge piyo bebeyo".to_string(),
+                content: "hoge piyo bebeyo 検索".to_string(),
+            })),
+            Node::Inline(Inline::Text(Text {
+                text: "123".to_string(),
+            })),
+        ];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+}
+
 mod plain {
     use super::*;
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -255,6 +255,15 @@ hoge"#;
             ];
             assert_eq!(mfm::parse(input).unwrap(), output);
         }
+
+        #[test]
+        fn open_tag_not_on_line_beginning() {
+            let input = "before> aaa";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "before> aaa".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
     }
 
     mod search {
@@ -399,6 +408,24 @@ hoge"#;
             ];
             assert_eq!(mfm::parse(input).unwrap(), output);
         }
+
+        #[test]
+        fn mark_not_on_line_ending() {
+            let input = "```\naaa\n```after";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "```\naaa\n```after".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn mark_not_on_line_beginning() {
+            let input = "before```\naaa\n```";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "before```\naaa\n```".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
     }
 
     mod math_block {
@@ -440,7 +467,6 @@ hoge"#;
         }
 
         #[test]
-        #[ignore]
         fn open_tag_not_on_line_beginning() {
             let input = "before\\[aaa\\]";
             let output = vec![Node::Inline(Inline::Text(Text {
@@ -478,6 +504,24 @@ hoge"#;
                     text: "after".to_string(),
                 })),
             ];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn close_tag_not_on_line_ending() {
+            let input = "<center>aaa</center>after";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "<center>aaa</center>after".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn open_tag_not_on_line_beginning() {
+            let input = "before<center>aaa</center>";
+            let output = vec![Node::Inline(Inline::Text(Text {
+                text: "before<center>aaa</center>".to_string(),
+            }))];
             assert_eq!(mfm::parse(input).unwrap(), output);
         }
     }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -495,6 +495,65 @@ hoge"#;
         }
     }
 
+    mod big {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let input = "***abc***";
+            let output = vec![Node::Inline(Inline::Fn(Fn {
+                name: "tada".to_string(),
+                args: Vec::new(),
+                children: vec![Inline::Text(Text {
+                    text: "abc".to_string(),
+                })],
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn inline_contents() {
+            let input = "***123**abc**123***";
+            let output = vec![Node::Inline(Inline::Fn(Fn {
+                name: "tada".to_string(),
+                args: Vec::new(),
+                children: vec![
+                    Inline::Text(Text {
+                        text: "123".to_string(),
+                    }),
+                    Inline::Bold(Bold(vec![Inline::Text(Text {
+                        text: "abc".to_string(),
+                    })])),
+                    Inline::Text(Text {
+                        text: "123".to_string(),
+                    }),
+                ],
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn multiple_line_contents() {
+            let input = "***123\n**abc**\n123***";
+            let output = vec![Node::Inline(Inline::Fn(Fn {
+                name: "tada".to_string(),
+                args: Vec::new(),
+                children: vec![
+                    Inline::Text(Text {
+                        text: "123\n".to_string(),
+                    }),
+                    Inline::Bold(Bold(vec![Inline::Text(Text {
+                        text: "abc".to_string(),
+                    })])),
+                    Inline::Text(Text {
+                        text: "\n123".to_string(),
+                    }),
+                ],
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
     mod bold {
         use super::*;
 
@@ -684,6 +743,17 @@ hoge"#;
                 )])))];
                 assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
             }
+        }
+
+        #[test]
+        fn big() {
+            let input = "<b><b>***abc***</b></b>";
+            let output = vec![Node::Inline(Inline::Bold(Bold(vec![Inline::Bold(Bold(
+                vec![Inline::Text(Text {
+                    text: "***abc***".to_string(),
+                })],
+            ))])))];
+            assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
         }
 
         mod bold {

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -495,6 +495,130 @@ hoge"#;
         }
     }
 
+    mod bold {
+        use super::*;
+
+        mod asta {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = "**abc**";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![Inline::Text(Text {
+                    text: "abc".to_string(),
+                })])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            #[ignore]
+            fn inline_contents() {
+                let input = "**123~~abc~~123**";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![
+                    Inline::Text(Text {
+                        text: "123".to_string(),
+                    }),
+                    Inline::Strike(Strike(vec![Inline::Text(Text {
+                        text: "abc".to_string(),
+                    })])),
+                    Inline::Text(Text {
+                        text: "123".to_string(),
+                    }),
+                ])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            #[ignore]
+            fn multiple_line_contents() {
+                let input = "**123\n~~abc~~\n123**";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![
+                    Inline::Text(Text {
+                        text: "123\n".to_string(),
+                    }),
+                    Inline::Strike(Strike(vec![Inline::Text(Text {
+                        text: "abc".to_string(),
+                    })])),
+                    Inline::Text(Text {
+                        text: "\n123".to_string(),
+                    }),
+                ])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+        }
+
+        mod tag {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = "<b>abc</b>";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![Inline::Text(Text {
+                    text: "abc".to_string(),
+                })])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            #[ignore]
+            fn inline_contents() {
+                let input = "<b>123~~abc~~123</b>";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![
+                    Inline::Text(Text {
+                        text: "123".to_string(),
+                    }),
+                    Inline::Strike(Strike(vec![Inline::Text(Text {
+                        text: "abc".to_string(),
+                    })])),
+                    Inline::Text(Text {
+                        text: "123".to_string(),
+                    }),
+                ])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            #[ignore]
+            fn multiple_line_contents() {
+                let input = "<b>123\n~~abc~~\n123</b>";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![
+                    Inline::Text(Text {
+                        text: "123\n".to_string(),
+                    }),
+                    Inline::Strike(Strike(vec![Inline::Text(Text {
+                        text: "abc".to_string(),
+                    })])),
+                    Inline::Text(Text {
+                        text: "\n123".to_string(),
+                    }),
+                ])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+        }
+
+        mod under {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = "__abc 123__";
+                let output = vec![Node::Inline(Inline::Bold(Bold(vec![Inline::Text(Text {
+                    text: "abc 123".to_string(),
+                })])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn non_ascii() {
+                let input = "__あ__";
+                let output = vec![Node::Inline(Inline::Text(Text {
+                    text: "__あ__".to_string(),
+                }))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+        }
+    }
+
     mod plain {
         use super::*;
 
@@ -557,6 +681,34 @@ hoge"#;
                     Block::Quote(Quote(vec![Node::Inline(Inline::Text(Text {
                         text: "**abc**".to_string(),
                     }))])),
+                )])))];
+                assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+            }
+        }
+
+        mod bold {
+            use super::*;
+
+            #[test]
+            #[ignore]
+            fn basic() {
+                let input = "<i><i>**abc**</i></i>";
+                let output = vec![Node::Inline(Inline::Italic(Italic(vec![Inline::Italic(
+                    Italic(vec![Inline::Text(Text {
+                        text: "**abc**".to_string(),
+                    })]),
+                )])))];
+                assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+            }
+
+            #[test]
+            #[ignore]
+            fn tag() {
+                let input = "<i><i><b>abc</b></i></i>";
+                let output = vec![Node::Inline(Inline::Italic(Italic(vec![Inline::Italic(
+                    Italic(vec![Inline::Text(Text {
+                        text: "<b>abc</b>".to_string(),
+                    })]),
                 )])))];
                 assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
             }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -727,6 +727,181 @@ hoge"#;
         }
     }
 
+    mod italic {
+        use super::*;
+
+        mod tag {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = "<i>abc</i>";
+                let output = vec![Node::Inline(Inline::Italic(Italic(vec![Inline::Text(
+                    Text {
+                        text: "abc".to_string(),
+                    },
+                )])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn inline_contents() {
+                let input = "<i>abc**123**abc</i>";
+                let output = vec![Node::Inline(Inline::Italic(Italic(vec![
+                    Inline::Text(Text {
+                        text: "abc".to_string(),
+                    }),
+                    Inline::Bold(Bold(vec![Inline::Text(Text {
+                        text: "123".to_string(),
+                    })])),
+                    Inline::Text(Text {
+                        text: "abc".to_string(),
+                    }),
+                ])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn multiple_line_contents() {
+                let input = "<i>abc\n**123**\nabc</i>";
+                let output = vec![Node::Inline(Inline::Italic(Italic(vec![
+                    Inline::Text(Text {
+                        text: "abc\n".to_string(),
+                    }),
+                    Inline::Bold(Bold(vec![Inline::Text(Text {
+                        text: "123".to_string(),
+                    })])),
+                    Inline::Text(Text {
+                        text: "\nabc".to_string(),
+                    }),
+                ])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+        }
+
+        mod asta {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = "*abc*";
+                let output = vec![Node::Inline(Inline::Italic(Italic(vec![Inline::Text(
+                    Text {
+                        text: "abc".to_string(),
+                    },
+                )])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn basic_2() {
+                let input = "before *abc* after";
+                let output = vec![
+                    Node::Inline(Inline::Text(Text {
+                        text: "before ".to_string(),
+                    })),
+                    Node::Inline(Inline::Italic(Italic(vec![Inline::Text(Text {
+                        text: "abc".to_string(),
+                    })]))),
+                    Node::Inline(Inline::Text(Text {
+                        text: " after".to_string(),
+                    })),
+                ];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn ignore_if_preceded_by_alnum() {
+                let input = "before*abc*after";
+                let output = vec![Node::Inline(Inline::Text(Text {
+                    text: "before*abc*after".to_string(),
+                }))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+
+                let input = "123*abc*123";
+                let output = vec![Node::Inline(Inline::Text(Text {
+                    text: "123*abc*123".to_string(),
+                }))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+
+                let input = "あいう*abc*えお";
+                let output = vec![
+                    Node::Inline(Inline::Text(Text {
+                        text: "あいう".to_string(),
+                    })),
+                    Node::Inline(Inline::Italic(Italic(vec![Inline::Text(Text {
+                        text: "abc".to_string(),
+                    })]))),
+                    Node::Inline(Inline::Text(Text {
+                        text: "えお".to_string(),
+                    })),
+                ];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+        }
+
+        mod under {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let input = "_abc_";
+                let output = vec![Node::Inline(Inline::Italic(Italic(vec![Inline::Text(
+                    Text {
+                        text: "abc".to_string(),
+                    },
+                )])))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn basic_2() {
+                let input = "before _abc_ after";
+                let output = vec![
+                    Node::Inline(Inline::Text(Text {
+                        text: "before ".to_string(),
+                    })),
+                    Node::Inline(Inline::Italic(Italic(vec![Inline::Text(Text {
+                        text: "abc".to_string(),
+                    })]))),
+                    Node::Inline(Inline::Text(Text {
+                        text: " after".to_string(),
+                    })),
+                ];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+
+            #[test]
+            fn ignore_if_preceded_by_alnum() {
+                let input = "before_abc_after";
+                let output = vec![Node::Inline(Inline::Text(Text {
+                    text: "before_abc_after".to_string(),
+                }))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+
+                let input = "123_abc_123";
+                let output = vec![Node::Inline(Inline::Text(Text {
+                    text: "123_abc_123".to_string(),
+                }))];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+
+                let input = "あいう_abc_えお";
+                let output = vec![
+                    Node::Inline(Inline::Text(Text {
+                        text: "あいう".to_string(),
+                    })),
+                    Node::Inline(Inline::Italic(Italic(vec![Inline::Text(Text {
+                        text: "abc".to_string(),
+                    })]))),
+                    Node::Inline(Inline::Text(Text {
+                        text: "えお".to_string(),
+                    })),
+                ];
+                assert_eq!(mfm::parse(input).unwrap(), output);
+            }
+        }
+    }
+
     mod plain {
         use super::*;
 
@@ -809,7 +984,6 @@ hoge"#;
             use super::*;
 
             #[test]
-            #[ignore]
             fn basic() {
                 let input = "<i><i>**abc**</i></i>";
                 let output = vec![Node::Inline(Inline::Italic(Italic(vec![Inline::Italic(
@@ -821,7 +995,6 @@ hoge"#;
             }
 
             #[test]
-            #[ignore]
             fn tag() {
                 let input = "<i><i><b>abc</b></i></i>";
                 let output = vec![Node::Inline(Inline::Italic(Italic(vec![Inline::Italic(
@@ -834,7 +1007,6 @@ hoge"#;
         }
 
         #[test]
-        #[ignore]
         fn small() {
             let input = "<i><i><small>abc</small></i></i>";
             let output = vec![Node::Inline(Inline::Italic(Italic(vec![Inline::Italic(
@@ -842,6 +1014,17 @@ hoge"#;
                     text: "<small>abc</small>".to_string(),
                 })]),
             )])))];
+            assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+        }
+
+        #[test]
+        fn italic() {
+            let input = "<b><b><i>abc</i></b></b>";
+            let output = vec![Node::Inline(Inline::Bold(Bold(vec![Inline::Bold(Bold(
+                vec![Inline::Text(Text {
+                    text: "<i>abc</i>".to_string(),
+                })],
+            ))])))];
             assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
         }
     }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1016,6 +1016,19 @@ hoge"#;
         }
     }
 
+    mod math_inline {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let input = r"\(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\)";
+            let output = vec![Node::Inline(Inline::MathInline(MathInline {
+                formula: r"x = {-b \pm \sqrt{b^2-4ac} \over 2a}".to_string(),
+            }))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
     mod plain {
         use super::*;
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -678,6 +678,55 @@ hoge"#;
         }
     }
 
+    mod small {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let input = "<small>abc</small>";
+            let output = vec![Node::Inline(Inline::Small(Small(vec![Inline::Text(
+                Text {
+                    text: "abc".to_string(),
+                },
+            )])))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn inline_contents() {
+            let input = "<small>123**abc**123</small>";
+            let output = vec![Node::Inline(Inline::Small(Small(vec![
+                Inline::Text(Text {
+                    text: "123".to_string(),
+                }),
+                Inline::Bold(Bold(vec![Inline::Text(Text {
+                    text: "abc".to_string(),
+                })])),
+                Inline::Text(Text {
+                    text: "123".to_string(),
+                }),
+            ])))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+
+        #[test]
+        fn multiple_line_contents() {
+            let input = "<small>123\n**abc**\n123</small>";
+            let output = vec![Node::Inline(Inline::Small(Small(vec![
+                Inline::Text(Text {
+                    text: "123\n".to_string(),
+                }),
+                Inline::Bold(Bold(vec![Inline::Text(Text {
+                    text: "abc".to_string(),
+                })])),
+                Inline::Text(Text {
+                    text: "\n123".to_string(),
+                }),
+            ])))];
+            assert_eq!(mfm::parse(input).unwrap(), output);
+        }
+    }
+
     mod plain {
         use super::*;
 
@@ -782,6 +831,18 @@ hoge"#;
                 )])))];
                 assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
             }
+        }
+
+        #[test]
+        #[ignore]
+        fn small() {
+            let input = "<i><i><small>abc</small></i></i>";
+            let output = vec![Node::Inline(Inline::Italic(Italic(vec![Inline::Italic(
+                Italic(vec![Inline::Text(Text {
+                    text: "<small>abc</small>".to_string(),
+                })]),
+            )])))];
+            assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
         }
     }
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -42,7 +42,6 @@ mod quote {
     }
 
     #[test]
-    #[ignore]
     fn nest_block() {
         let input = r#"
 > <center>
@@ -343,6 +342,38 @@ mod math_block {
         let output = vec![Node::Inline(Inline::Text(Text {
             text: "before\\[aaa\\]".to_string(),
         }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+}
+
+mod center {
+    use super::*;
+
+    #[test]
+    fn single_text() {
+        let input = "<center>abc</center>";
+        let output = vec![Node::Block(Block::Center(Center(vec![Inline::Text(
+            Text {
+                text: "abc".to_string(),
+            },
+        )])))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn multiple_text() {
+        let input = "before\n<center>\nabc\n123\n\npiyo\n</center>\nafter";
+        let output = vec![
+            Node::Inline(Inline::Text(Text {
+                text: "before".to_string(),
+            })),
+            Node::Block(Block::Center(Center(vec![Inline::Text(Text {
+                text: "abc\n123\n\npiyo".to_string(),
+            })]))),
+            Node::Inline(Inline::Text(Text {
+                text: "after".to_string(),
+            })),
+        ];
         assert_eq!(mfm::parse(input).unwrap(), output);
     }
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -298,6 +298,55 @@ mod code_block {
     }
 }
 
+mod math_block {
+    use super::*;
+
+    #[test]
+    fn oneline() {
+        let input = "\\[math1\\]";
+        let output = vec![Node::Block(Block::MathBlock(MathBlock {
+            formula: "math1".to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn text_around_block() {
+        let input = "abc\n\\[math1\\]\n123";
+        let output = vec![
+            Node::Inline(Inline::Text(Text {
+                text: "abc".to_string(),
+            })),
+            Node::Block(Block::MathBlock(MathBlock {
+                formula: "math1".to_string(),
+            })),
+            Node::Inline(Inline::Text(Text {
+                text: "123".to_string(),
+            })),
+        ];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn close_tag_not_on_line_ending() {
+        let input = "\\[aaa\\]after";
+        let output = vec![Node::Inline(Inline::Text(Text {
+            text: "\\[aaa\\]after".to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    #[ignore]
+    fn open_tag_not_on_line_beginning() {
+        let input = "before\\[aaa\\]";
+        let output = vec![Node::Inline(Inline::Text(Text {
+            text: "before\\[aaa\\]".to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+}
+
 mod plain {
     use super::*;
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,0 +1,223 @@
+use mfm::node::*;
+
+mod text {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let input = "abc";
+        let output = vec![Node::Inline(Inline::Text(Text {
+            text: "abc".to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+}
+
+mod quote {
+    use super::*;
+
+    #[test]
+    fn single_line() {
+        let input = "> abc";
+        let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Inline(
+            Inline::Text(Text {
+                text: "abc".to_string(),
+            }),
+        )])))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn multiple_line() {
+        let input = r#"
+> abc
+> 123
+"#;
+        let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Inline(
+            Inline::Text(Text {
+                text: "abc\n123".to_string(),
+            }),
+        )])))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    #[ignore]
+    fn nest_block() {
+        let input = r#"
+> <center>
+> a
+> </center>
+"#;
+        let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
+            Block::Center(Center(vec![Inline::Text(Text {
+                text: "a".to_string(),
+            })])),
+        )])))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    #[ignore]
+    fn nest_block_with_inline() {
+        let input = r#"
+> <center>
+> I'm @ai, An bot of misskey!
+> </center>
+"#;
+        let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
+            Block::Center(Center(vec![
+                Inline::Text(Text {
+                    text: "I'm ".to_string(),
+                }),
+                Inline::Mention(Mention {
+                    username: "ai".to_string(),
+                    host: None,
+                    acct: "@ai".to_string(),
+                }),
+                Inline::Text(Text {
+                    text: ", An bot of misskey!".to_string(),
+                }),
+            ])),
+        )])))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn multiple_line_with_empty_line() {
+        let input = r#"
+> abc
+>
+> 123
+"#;
+        let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Inline(
+            Inline::Text(Text {
+                text: "abc\n\n123".to_string(),
+            }),
+        )])))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn single_empty_line() {
+        let input = "> ";
+        let output = vec![Node::Inline(Inline::Text(Text {
+            text: "> ".to_string(),
+        }))];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn ignore_empty_line_after_quote() {
+        let input = r#"
+> foo
+> bar
+
+hoge"#;
+        let output = vec![
+            Node::Block(Block::Quote(Quote(vec![Node::Inline(Inline::Text(
+                Text {
+                    text: "foo\nbar".to_string(),
+                },
+            ))]))),
+            Node::Inline(Inline::Text(Text {
+                text: "hoge".to_string(),
+            })),
+        ];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+
+    #[test]
+    fn two_quote_blocks() {
+        let input = r#"
+> foo
+
+> bar
+
+hoge"#;
+        let output = vec![
+            Node::Block(Block::Quote(Quote(vec![Node::Inline(Inline::Text(
+                Text {
+                    text: "foo".to_string(),
+                },
+            ))]))),
+            Node::Block(Block::Quote(Quote(vec![Node::Inline(Inline::Text(
+                Text {
+                    text: "bar".to_string(),
+                },
+            ))]))),
+            Node::Inline(Inline::Text(Text {
+                text: "hoge".to_string(),
+            })),
+        ];
+        assert_eq!(mfm::parse(input).unwrap(), output);
+    }
+}
+
+mod plain {
+    use super::*;
+
+    #[test]
+    fn multiple_line() {
+        let input = "a\n<plain>\n**Hello**\nworld\n</plain>\nb";
+        let output = vec![
+            Node::Inline(Inline::Text(Text {
+                text: "a\n".to_string(),
+            })),
+            Node::Inline(Inline::Plain(Plain(vec![Text {
+                text: "**Hello**\nworld".to_string(),
+            }]))),
+            Node::Inline(Inline::Text(Text {
+                text: "\nb".to_string(),
+            })),
+        ];
+        assert_eq!(mfm::parse(input).unwrap(), output)
+    }
+
+    #[test]
+    fn single_line() {
+        let input = "a\n<plain>\n**Hello** world\n</plain>\nb";
+        let output = vec![
+            Node::Inline(Inline::Text(Text {
+                text: "a\n".to_string(),
+            })),
+            Node::Inline(Inline::Plain(Plain(vec![Text {
+                text: "**Hello** world".to_string(),
+            }]))),
+            Node::Inline(Inline::Text(Text {
+                text: "\nb".to_string(),
+            })),
+        ];
+        assert_eq!(mfm::parse(input).unwrap(), output)
+    }
+}
+
+mod nesting_limit {
+    use super::*;
+
+    mod quote {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let input = ">>> abc";
+            let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
+                Block::Quote(Quote(vec![Node::Inline(Inline::Text(Text {
+                    text: "> abc".to_string(),
+                }))])),
+            )])))];
+            assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+        }
+
+        #[test]
+        fn basic2() {
+            let input = ">> **abc**";
+            let output = vec![Node::Block(Block::Quote(Quote(vec![Node::Block(
+                Block::Quote(Quote(vec![Node::Inline(Inline::Text(Text {
+                    text: "**abc**".to_string(),
+                }))])),
+            )])))];
+            assert_eq!(mfm::parse_with_nest_limit(input, 2).unwrap(), output);
+        }
+    }
+}


### PR DESCRIPTION
mfmパーサーを実装しました

- `cargo run --release --example parse` でCLIが起動します
- mfm.js の全てのテストを通過しました
- mfm.js の `parse`, `parseSimple` 以外のapiは実装していません
- Unicode絵文字の判定にはtwemoji-parserではなく [emojis](https://crates.io/crates/emojis) を使用しています